### PR TITLE
More README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # matio-cpp <a href="https://isocpp.org"><img src="https://img.shields.io/badge/standard-C++14-blue.svg?style=flat&logo=c%2B%2B" alt="C++ Standard" /></a> 
 
 **``matio-cpp``** is a C++ wrapper for the [``matio``](https://github.com/tbeu/matio) library, automatically dealing with memory allocation and deallocation.
+It can be used for reading and writing binary MATLAB `.mat` files from C++, without the need to access or rely on MATLAB's own shared libraries.
 
 # Overview
 
@@ -53,10 +54,10 @@ In order to allow CMake finding ``matio-cpp``, it is necessary that the installa
   In order to use ``matio-cpp`` in your project, add the following in your ``CMakeLists.txt``
 ```cmake
 find_package(matioCpp REQUIRED)
-.
-.
-.
-target_link_libraries(yourTarget matioCpp::matioCpp)
+
+# ...
+
+target_link_libraries(yourTarget PRIVATE matioCpp::matioCpp)
 ```
 
 # Supported Data Types

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The depencies are [``CMake``](https://cmake.org/) (minimum version 3.10) and [``
 - Linux: ``sudo apt install libmatio-dev``
 - macOS: ``brew install libmatio``
 - Windows, via [``vcpkg``](https://github.com/microsoft/vcpkg): ``vcpkg install --triplet x64-windows matio``
+
 For running the tests, it is necessary to install [`Catch2`](https://github.com/catchorg/Catch2). Where supported, [``valgrind``](https://valgrind.org/) can be installed to check for memory leaks.
 
 ## Linux/macOS


### PR DESCRIPTION
* Clarify the scope of the library in the library description, to be clear also for who do not know what matio is. 
* Make CMake code more easy to copy&paste 
* Avoid to use deprecated `target_link_libraries` signature
* Make sure that the sentence on test-related dependencies is not in the line of Windows dependencies