### PR TITLE
Fix the linking for external projects

### DIFF
--- a/include/matioCpp/Variable.h
+++ b/include/matioCpp/Variable.h
@@ -361,15 +361,11 @@ public:
 
     /**
      * @brief Cast the variable as a String.
-     *
-     * The implementation is in Vector.tpp
      */
     matioCpp::String asString();
 
     /**
      * @brief Cast the variable as a const Vector
-     *
-     * The implementation is in Vector.tpp
      */
     const matioCpp::String asString() const;
 

--- a/include/matioCpp/impl/Vector.tpp
+++ b/include/matioCpp/impl/Vector.tpp
@@ -376,14 +376,4 @@ const matioCpp::Vector<T> matioCpp::Variable::asVector() const
     return matioCpp::Vector<T>(*m_handler);
 }
 
-matioCpp::String matioCpp::Variable::asString()
-{
-    return matioCpp::Vector<char>(*m_handler);
-}
-
-const matioCpp::String matioCpp::Variable::asString() const
-{
-    return matioCpp::Vector<char>(*m_handler);
-}
-
 #endif // MATIOCPP_VECTOR_TPP

--- a/src/Variable.cpp
+++ b/src/Variable.cpp
@@ -11,6 +11,7 @@
 #include <matioCpp/CellArray.h>
 #include <matioCpp/Struct.h>
 #include <matioCpp/StructArray.h>
+#include <matioCpp/Vector.h>
 
 bool matioCpp::Variable::initializeVariable(const std::string& name, const VariableType& variableType, const ValueType& valueType, matioCpp::Span<const size_t> dimensions, void* data)
 {
@@ -571,4 +572,14 @@ matioCpp::StructArray matioCpp::Variable::asStructArray()
 const matioCpp::StructArray matioCpp::Variable::asStructArray() const
 {
     return matioCpp::StructArray(*m_handler);
+}
+
+matioCpp::String matioCpp::Variable::asString()
+{
+    return matioCpp::Vector<char>(*m_handler);
+}
+
+const matioCpp::String matioCpp::Variable::asString() const
+{
+    return matioCpp::Vector<char>(*m_handler);
 }


### PR DESCRIPTION
I noticed that when linking ``matioCpp`` from another application, I had the following error
```
/usr/bin/ld: CMakeFiles/MasImuTest.dir/src/MasImuTest.cpp.o: in function `matioCpp::Variable::asString()':
/home/sdafarra/Software/matio-cpp/build/install/include/matioCpp/impl/Vector.tpp:380: multiple definition of `matioCpp::Variable::asString()'; CMakeFiles/MasImuTest.dir/src/main.cpp.o:/home/sdafarra/Software/matio-cpp/build/install/include/matioCpp/impl/Vector.tpp:380: first defined here
/usr/bin/ld: CMakeFiles/MasImuTest.dir/src/MasImuTest.cpp.o: in function `matioCpp::Variable::asString() const':
/home/sdafarra/Software/matio-cpp/build/install/include/matioCpp/impl/Vector.tpp:385: multiple definition of `matioCpp::Variable::asString() const'; CMakeFiles/MasImuTest.dir/src/main.cpp.o:/home/sdafarra/Software/matio-cpp/build/install/include/matioCpp/impl/Vector.tpp:385: first defined here
collect2: error: ld returned 1 exit status
make[2]: *** [utilities/MasImuTest/CMakeFiles/MasImuTest.dir/build.make:151: bin/MasImuTest] Error 1
make[1]: *** [CMakeFiles/Makefile2:2385: utilities/MasImuTest/CMakeFiles/MasImuTest.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```

This occurred when ``matioCpp`` was linked from an executable that was including other directories. To be honest, I did not really understand why this happening, but I noticed that ``asString`` implementation does not require any template, so I moved it to the ``Variable`` implementation. This fixed the issue.