### PR TITLE
Removing auto-assign-issue app in favor of a github action.

### DIFF
--- a/.github/auto-assign-issues.yml
+++ b/.github/auto-assign-issues.yml
@@ -1,8 +1,0 @@
-# If enabled, auto-assigns users when a new issue is created 
-# Defaults to true, allows you to install the app globally, and disable on a per-repo basis
-addAssignees: true
-
-# The list of users to assign to new issues. 
-# If empty or not provided, the repository owner is assigned
-assignees:
-  - S-Dafarra

--- a/.github/workflows/assign-issue.yml
+++ b/.github/workflows/assign-issue.yml
@@ -12,4 +12,4 @@ jobs:
         uses: pozil/auto-assign-issue@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          assignees: S-Dafarra
+          assignees: ${{ secrets.DEFAULT_ISSUE_ASSIGNEE }}

--- a/.github/workflows/assign-issue.yml
+++ b/.github/workflows/assign-issue.yml
@@ -1,0 +1,15 @@
+name: Automatic issue assignment
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Auto-assign issue'
+        uses: pozil/auto-assign-issue@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          assignees: S-Dafarra


### PR DESCRIPTION
The app to auto-assign issues got archived https://github.com/andrewlock/auto-assign-issues/issues/3. Moving to a similar github action